### PR TITLE
Replace `DatabaseProviderFactory` trait bound with `SateRootCalculator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6410,6 +6410,7 @@ dependencies = [
  "clap 4.5.21",
  "eyre",
  "op-rbuilder-payload-builder",
+ "rbuilder",
  "rbuilder-bundle-pool-operations",
  "reth-basic-payload-builder",
  "reth-evm",

--- a/crates/op-rbuilder/node/Cargo.toml
+++ b/crates/op-rbuilder/node/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 op-rbuilder-payload-builder = { path = "../payload_builder" }
 transaction-pool-bundle-ext = { path = "../../transaction-pool-bundle-ext" }
 rbuilder-bundle-pool-operations = { path = "../../transaction-pool-bundle-ext/bundle_pool_ops/rbuilder" }
+rbuilder = { path = "../../rbuilder" }
 
 # alloy
 alloy-consensus.workspace = true

--- a/crates/op-rbuilder/node/src/node.rs
+++ b/crates/op-rbuilder/node/src/node.rs
@@ -4,6 +4,7 @@
 //! and overrides the Pool and Payload Builders.
 
 use alloy_consensus::Header;
+use rbuilder::roothash::StateRootCalculator;
 use rbuilder_bundle_pool_operations::BundlePoolOps;
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
 use reth_evm::ConfigureEvm;
@@ -31,7 +32,6 @@ use reth_transaction_pool::{
 };
 use reth_trie_db::MerklePatriciaTrie;
 use std::{path::PathBuf, sync::Arc};
-use rbuilder::roothash::StateRootCalculator;
 use transaction_pool_bundle_ext::{
     BundlePoolOperations, BundleSupportedPool, TransactionPoolBundleExt,
 };
@@ -78,8 +78,8 @@ impl OpRbuilderNode {
         Node: FullNodeTypes<
             Types: NodeTypesWithEngine<Engine = OpEngineTypes, ChainSpec = OpChainSpec>,
         >,
-        Node::Provider:  StateRootCalculator,
-        <<Node as FullNodeTypes>::Provider as DatabaseProviderFactory>::Provider: BlockReader + StateRootCalculator,
+        Node::Provider: StateRootCalculator,
+        <<Node as FullNodeTypes>::Provider as DatabaseProviderFactory>::Provider: BlockReader,
     {
         let OpRbuilderArgs {
             disable_txpool_gossip,
@@ -104,8 +104,8 @@ impl OpRbuilderNode {
 impl<N> Node<N> for OpRbuilderNode
 where
     N: FullNodeTypes<Types: NodeTypesWithEngine<Engine = OpEngineTypes, ChainSpec = OpChainSpec>>,
-    N::Provider:  StateRootCalculator,
-    <<N as FullNodeTypes>::Provider as DatabaseProviderFactory>::Provider: BlockReader + StateRootCalculator,
+    N::Provider: StateRootCalculator,
+    <<N as FullNodeTypes>::Provider as DatabaseProviderFactory>::Provider: BlockReader,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
@@ -165,14 +165,12 @@ pub type OpRbuilderTransactionPool<Client, S> = BundleSupportedPool<
 impl<Node> PoolBuilder<Node> for OpRbuilderPoolBuilder
 where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec = OpChainSpec>>,
-    Node::Provider:  StateRootCalculator,
-    <<Node as FullNodeTypes>::Provider as DatabaseProviderFactory>::Provider:
-        BlockReader ,
+    Node::Provider: StateRootCalculator,
+    <<Node as FullNodeTypes>::Provider as DatabaseProviderFactory>::Provider: BlockReader,
 {
     type Pool = OpRbuilderTransactionPool<Node::Provider, DiskFileBlobStore>;
 
-    async fn build_pool(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Pool>
-        {
+    async fn build_pool(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Pool> {
         let data_dir = ctx.config().datadir();
         let blob_store = DiskFileBlobStore::open(data_dir.blobstore(), Default::default())?;
 

--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -14,8 +14,7 @@ use ahash::HashSet;
 use alloy_primitives::{Address, U256};
 use reth::revm::cached::CachedReads;
 use reth_chainspec::ChainSpec;
-use reth_db::Database;
-use reth_provider::{BlockReader, DatabaseProviderFactory, HeaderProvider, StateProviderFactory};
+use reth_provider::{HeaderProvider, StateProviderFactory};
 use serde::{Deserialize, Serialize};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 

--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     live_builder::cli::LiveBuilderConfig,
     primitives::{OrderId, SimulatedOrder},
+    roothash::StateRootCalculator,
     utils::{clean_extradata, Signer},
 };
 use ahash::HashSet;
@@ -107,7 +108,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn backtest_simulate_block<P, DB, ConfigType>(
+pub fn backtest_simulate_block<P, ConfigType>(
     block_data: BlockData,
     provider: P,
     chain_spec: Arc<ChainSpec>,
@@ -118,12 +119,7 @@ pub fn backtest_simulate_block<P, DB, ConfigType>(
     sbundle_mergeabe_signers: &[Address],
 ) -> eyre::Result<BlockBacktestValue>
 where
-    DB: Database + Clone + 'static,
-    P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-        + StateProviderFactory
-        + HeaderProvider
-        + Clone
-        + 'static,
+    P: StateProviderFactory + HeaderProvider + StateRootCalculator + Clone + 'static,
     ConfigType: LiveBuilderConfig,
 {
     let BacktestBlockInput {

--- a/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
@@ -11,8 +11,7 @@ use crate::{
 use alloy_primitives::utils::format_ether;
 use clap::Parser;
 use csv_output::{CSVOutputRow, CSVResultWriter};
-use reth_db::Database;
-use reth_provider::{BlockReader, DatabaseProviderFactory, HeaderProvider, StateProviderFactory};
+use reth_provider::{HeaderProvider, StateProviderFactory};
 use std::{io, path::PathBuf};
 use tracing::info;
 

--- a/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
@@ -6,6 +6,7 @@ use crate::{
         BlockData, HistoricalDataStorage,
     },
     live_builder::{base_config::load_config_toml_and_env, cli::LiveBuilderConfig},
+    roothash::StateRootCalculator,
 };
 use alloy_primitives::utils::format_ether;
 use clap::Parser;
@@ -107,7 +108,7 @@ where
     Ok(())
 }
 
-fn process_redisribution<P, DB, ConfigType>(
+fn process_redisribution<P, ConfigType>(
     block_data: BlockData,
     csv_writer: Option<&mut CSVResultWriter>,
     json_accum: Option<&mut Vec<RedistributionBlockOutput>>,
@@ -116,12 +117,7 @@ fn process_redisribution<P, DB, ConfigType>(
     distribute_to_mempool_txs: bool,
 ) -> eyre::Result<()>
 where
-    DB: Database + Clone + 'static,
-    P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-        + StateProviderFactory
-        + HeaderProvider
-        + Clone
-        + 'static,
+    P: StateProviderFactory + StateRootCalculator + HeaderProvider + Clone + 'static,
     ConfigType: LiveBuilderConfig,
 {
     let block_number = block_data.block_number;

--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -24,8 +24,7 @@ use alloy_primitives::{utils::format_ether, Address, B256, I256, U256};
 pub use cli::run_backtest_redistribute;
 use rayon::prelude::*;
 use reth_chainspec::ChainSpec;
-use reth_db::Database;
-use reth_provider::{BlockReader, DatabaseProviderFactory, HeaderProvider, StateProviderFactory};
+use reth_provider::{HeaderProvider, StateProviderFactory};
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::{max, min},

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -89,7 +89,6 @@ async fn main() -> eyre::Result<()> {
         mpsc::channel(order_input_config.input_channel_buffer_size);
     let builder = LiveBuilder::<
         ProviderFactoryReopener<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>,
-        Arc<DatabaseEnv>,
         MevBoostSlotDataGenerator,
     > {
         watchdog_timeout: Some(Duration::from_secs(10000)),
@@ -199,18 +198,14 @@ impl DummyBuildingAlgorithm {
         }
     }
 
-    fn build_block<P, DB>(
+    fn build_block<P>(
         &self,
         orders: Vec<SimulatedOrder>,
         provider: P,
         ctx: &BlockBuildingContext,
     ) -> eyre::Result<Box<dyn BlockBuildingHelper>>
     where
-        DB: Database + Clone + 'static,
-        P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-            + StateProviderFactory
-            + Clone
-            + 'static,
+        P: StateProviderFactory + Clone + 'static,
     {
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
             provider.clone(),
@@ -231,13 +226,9 @@ impl DummyBuildingAlgorithm {
     }
 }
 
-impl<P, DB> BlockBuildingAlgorithm<P, DB> for DummyBuildingAlgorithm
+impl<P> BlockBuildingAlgorithm<P> for DummyBuildingAlgorithm
 where
-    DB: Database + Clone + 'static,
-    P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-        + StateProviderFactory
-        + Clone
-        + 'static,
+    P: StateProviderFactory + Clone + 'static,
 {
     fn name(&self) -> String {
         BUILDER_NAME.to_string()

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -34,7 +34,7 @@ use rbuilder::{
         mev_boost::{MevBoostRelay, RelayConfig},
         SimulatedOrder,
     },
-    roothash::RootHashConfig,
+    roothash::{RootHashConfig, StateRootCalculator},
     utils::{ProviderFactoryReopener, Signer},
 };
 use reth_chainspec::MAINNET;
@@ -205,7 +205,7 @@ impl DummyBuildingAlgorithm {
         ctx: &BlockBuildingContext,
     ) -> eyre::Result<Box<dyn BlockBuildingHelper>>
     where
-        P: StateProviderFactory + Clone + 'static,
+        P: StateProviderFactory + StateRootCalculator + Clone + 'static,
     {
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
             provider.clone(),
@@ -228,7 +228,7 @@ impl DummyBuildingAlgorithm {
 
 impl<P> BlockBuildingAlgorithm<P> for DummyBuildingAlgorithm
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     fn name(&self) -> String {
         BUILDER_NAME.to_string()

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -38,10 +38,10 @@ use rbuilder::{
     utils::{ProviderFactoryReopener, Signer},
 };
 use reth_chainspec::MAINNET;
-use reth_db::{database::Database, DatabaseEnv};
+use reth_db::DatabaseEnv;
 use reth_node_api::NodeTypesWithDBAdapter;
 use reth_node_ethereum::EthereumNode;
-use reth_provider::{BlockReader, DatabaseProviderFactory, StateProviderFactory};
+use reth_provider::StateProviderFactory;
 use tokio::{
     signal::ctrl_c,
     sync::{broadcast, mpsc},

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -18,13 +18,9 @@ use crate::{
 };
 use ahash::{HashMap, HashSet};
 use reth::revm::cached::CachedReads;
-use reth_db::database::Database;
-use reth_provider::{BlockReader, DatabaseProviderFactory, StateProviderFactory};
+use reth_provider::StateProviderFactory;
 use serde::Deserialize;
-use std::{
-    marker::PhantomData,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info_span, trace};
 
@@ -179,9 +175,6 @@ pub struct OrderingBuilderContext<P> {
     // scratchpad
     failed_orders: HashSet<OrderId>,
     order_attempts: HashMap<OrderId, usize>,
-
-    //TODO: delete me?
-    phantom: PhantomData<P>,
 }
 
 impl<P> OrderingBuilderContext<P>
@@ -204,7 +197,6 @@ where
             cached_reads: None,
             failed_orders: HashSet::default(),
             order_attempts: HashMap::default(),
-            phantom: PhantomData,
         }
     }
 

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -61,13 +61,9 @@ impl OrderingBuilderConfig {
     }
 }
 
-pub fn run_ordering_builder<P, DB>(input: LiveBuilderInput<P, DB>, config: &OrderingBuilderConfig)
+pub fn run_ordering_builder<P>(input: LiveBuilderInput<P>, config: &OrderingBuilderConfig)
 where
-    DB: Database + Clone + 'static,
-    P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-        + StateProviderFactory
-        + Clone
-        + 'static,
+    P: StateProviderFactory + Clone + 'static,
 {
     let mut order_intake_consumer = OrderIntakeConsumer::new(
         input.provider.clone(),
@@ -130,16 +126,12 @@ where
     }
 }
 
-pub fn backtest_simulate_block<P, DB>(
+pub fn backtest_simulate_block<P>(
     ordering_config: OrderingBuilderConfig,
     input: BacktestSimulateBlockInput<'_, P>,
 ) -> eyre::Result<(Block, CachedReads)>
 where
-    DB: Database + Clone + 'static,
-    P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-        + StateProviderFactory
-        + Clone
-        + 'static,
+    P: StateProviderFactory + Clone + 'static,
 {
     let use_suggested_fee_recipient_as_coinbase = ordering_config.coinbase_payment;
     let state_provider = input
@@ -174,7 +166,7 @@ where
 }
 
 #[derive(Debug)]
-pub struct OrderingBuilderContext<P, DB> {
+pub struct OrderingBuilderContext<P> {
     provider: P,
     builder_name: String,
     ctx: BlockBuildingContext,
@@ -188,16 +180,13 @@ pub struct OrderingBuilderContext<P, DB> {
     failed_orders: HashSet<OrderId>,
     order_attempts: HashMap<OrderId, usize>,
 
-    phantom: PhantomData<DB>,
+    //TODO: delete me?
+    phantom: PhantomData<P>,
 }
 
-impl<P, DB> OrderingBuilderContext<P, DB>
+impl<P> OrderingBuilderContext<P>
 where
-    DB: Database + Clone + 'static,
-    P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-        + StateProviderFactory
-        + Clone
-        + 'static,
+    P: StateProviderFactory + Clone + 'static,
 {
     pub fn new(
         provider: P,
@@ -358,13 +347,9 @@ impl OrderingBuildingAlgorithm {
     }
 }
 
-impl<P, DB> BlockBuildingAlgorithm<P, DB> for OrderingBuildingAlgorithm
+impl<P> BlockBuildingAlgorithm<P> for OrderingBuildingAlgorithm
 where
-    DB: Database + Clone + 'static,
-    P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-        + StateProviderFactory
-        + Clone
-        + 'static,
+    P: StateProviderFactory + Clone + 'static,
 {
     fn name(&self) -> String {
         self.name.clone()

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -14,7 +14,7 @@ use crate::{
         BlockBuildingContext, BlockOrders, ExecutionError, Sorting,
     },
     primitives::{AccountNonce, OrderId},
-    roothash::RootHashConfig,
+    roothash::{RootHashConfig, StateRootCalculator},
 };
 use ahash::{HashMap, HashSet};
 use reth::revm::cached::CachedReads;
@@ -63,7 +63,7 @@ impl OrderingBuilderConfig {
 
 pub fn run_ordering_builder<P>(input: LiveBuilderInput<P>, config: &OrderingBuilderConfig)
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     let mut order_intake_consumer = OrderIntakeConsumer::new(
         input.provider.clone(),
@@ -131,7 +131,7 @@ pub fn backtest_simulate_block<P>(
     input: BacktestSimulateBlockInput<'_, P>,
 ) -> eyre::Result<(Block, CachedReads)>
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     let use_suggested_fee_recipient_as_coinbase = ordering_config.coinbase_payment;
     let state_provider = input
@@ -186,7 +186,7 @@ pub struct OrderingBuilderContext<P> {
 
 impl<P> OrderingBuilderContext<P>
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     pub fn new(
         provider: P,
@@ -349,7 +349,7 @@ impl OrderingBuildingAlgorithm {
 
 impl<P> BlockBuildingAlgorithm<P> for OrderingBuildingAlgorithm
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     fn name(&self) -> String {
         self.name.clone()

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// Assembles block building results from the best orderings of order groups.
-pub struct BlockBuildingResultAssembler<P, DB> {
+pub struct BlockBuildingResultAssembler<P> {
     provider: P,
     ctx: BlockBuildingContext,
     cancellation_token: CancellationToken,
@@ -38,16 +38,13 @@ pub struct BlockBuildingResultAssembler<P, DB> {
     best_results: Arc<BestResults>,
     run_id: u64,
     last_version: Option<u64>,
-    phantom: PhantomData<DB>,
+    //TODO: delete me?
+    phantom: PhantomData<P>,
 }
 
-impl<P, DB> BlockBuildingResultAssembler<P, DB>
+impl<P> BlockBuildingResultAssembler<P>
 where
-    DB: Database + Clone + 'static,
-    P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-        + StateProviderFactory
-        + Clone
-        + 'static,
+    P: StateProviderFactory + Clone + 'static,
 {
     /// Creates a new `BlockBuildingResultAssembler`.
     ///

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -5,9 +5,8 @@ use super::{
 use ahash::HashMap;
 use alloy_primitives::utils::format_ether;
 use reth::revm::cached::CachedReads;
-use reth_db::Database;
-use reth_provider::{BlockReader, DatabaseProviderFactory, StateProviderFactory};
-use std::{marker::PhantomData, sync::Arc, time::Instant};
+use reth_provider::StateProviderFactory;
+use std::{sync::Arc, time::Instant};
 use time::OffsetDateTime;
 use tokio_util::sync::CancellationToken;
 use tracing::{info_span, trace};
@@ -38,8 +37,6 @@ pub struct BlockBuildingResultAssembler<P> {
     best_results: Arc<BestResults>,
     run_id: u64,
     last_version: Option<u64>,
-    //TODO: delete me?
-    phantom: PhantomData<P>,
 }
 
 impl<P> BlockBuildingResultAssembler<P>
@@ -80,7 +77,6 @@ where
             best_results,
             run_id: 0,
             last_version: None,
-            phantom: PhantomData,
         }
     }
 

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         BlockBuildingContext,
     },
-    roothash::RootHashConfig,
+    roothash::{RootHashConfig, StateRootCalculator},
 };
 
 /// Assembles block building results from the best orderings of order groups.
@@ -44,7 +44,7 @@ pub struct BlockBuildingResultAssembler<P> {
 
 impl<P> BlockBuildingResultAssembler<P>
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     /// Creates a new `BlockBuildingResultAssembler`.
     ///

--- a/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
@@ -36,8 +36,7 @@ use crate::{
     roothash::{RootHashConfig, StateRootCalculator},
 };
 use reth::revm::cached::CachedReads;
-use reth_db::database::Database;
-use reth_provider::{BlockReader, DatabaseProviderFactory, StateProviderFactory};
+use reth_provider::StateProviderFactory;
 
 use self::{
     block_building_result_assembler::BlockBuildingResultAssembler,
@@ -176,8 +175,7 @@ where
 /// * `config`: Configuration parameters for the parallel builder.
 ///
 /// # Type Parameters
-/// * `DB`: The database type, which must implement Database, Clone, and have a static lifetime.
-//TODO: update the docs above
+/// * `P`: The Provider type, which must implement StateProviderFactory, StateRootCalculator, Clone, and have a static lifetime.
 pub fn run_parallel_builder<P>(input: LiveBuilderInput<P>, config: &ParallelBuilderConfig)
 where
     P: StateProviderFactory + StateRootCalculator + Clone + 'static,

--- a/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
@@ -33,7 +33,7 @@ use crate::{
         BacktestSimulateBlockInput, Block, BlockBuildingAlgorithm, BlockBuildingAlgorithmInput,
         LiveBuilderInput,
     },
-    roothash::RootHashConfig,
+    roothash::{RootHashConfig, StateRootCalculator},
 };
 use reth::revm::cached::CachedReads;
 use reth_db::database::Database;
@@ -83,7 +83,7 @@ struct ParallelBuilder<P> {
 
 impl<P> ParallelBuilder<P>
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     /// Creates a ParallelBuilder.
     /// Sets up the various components and communication channels.
@@ -180,7 +180,7 @@ where
 //TODO: update the docs above
 pub fn run_parallel_builder<P>(input: LiveBuilderInput<P>, config: &ParallelBuilderConfig)
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     let cancel_for_results_aggregator = input.cancel.clone();
     let cancel_for_block_building_result_assembler = input.cancel.clone();
@@ -266,7 +266,7 @@ pub fn parallel_build_backtest<P>(
     config: ParallelBuilderConfig,
 ) -> Result<(Block, CachedReads)>
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     let start_time = Instant::now();
 
@@ -391,7 +391,7 @@ impl ParallelBuildingAlgorithm {
 
 impl<P> BlockBuildingAlgorithm<P> for ParallelBuildingAlgorithm
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     fn name(&self) -> String {
         self.name.clone()

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -14,9 +14,8 @@ use alloy_consensus::{Header, EMPTY_OMMER_ROOT_HASH};
 use alloy_primitives::{Address, Bytes, Sealable, U256};
 pub use block_orders::BlockOrders;
 use eth_sparse_mpt::SparseTrieSharedCache;
-use reth_db::Database;
 use reth_primitives::BlockBody;
-use reth_provider::{BlockReader, DatabaseProviderFactory, StateProviderFactory};
+use reth_provider::StateProviderFactory;
 
 use crate::{
     primitives::{Order, OrderId, SimValue, SimulatedOrder, TransactionSignedEcRecoveredWithBlobs},

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -20,7 +20,7 @@ use reth_provider::{BlockReader, DatabaseProviderFactory, StateProviderFactory};
 
 use crate::{
     primitives::{Order, OrderId, SimValue, SimulatedOrder, TransactionSignedEcRecoveredWithBlobs},
-    roothash::{calculate_state_root, RootHashConfig, RootHashError},
+    roothash::{calculate_state_root, RootHashConfig, RootHashError, StateRootCalculator},
     utils::{a2r_withdrawal, calc_gas_limit, timestamp_as_u64, Signer},
 };
 use ahash::HashSet;
@@ -597,7 +597,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
 
     /// Mostly based on reth's (v1.1.1) default_ethereum_payload_builder.
     #[allow(clippy::too_many_arguments)]
-    pub fn finalize<P, DB>(
+    pub fn finalize<P>(
         self,
         state: &mut BlockState,
         ctx: &BlockBuildingContext,
@@ -605,11 +605,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         root_hash_config: RootHashConfig,
     ) -> Result<FinalizeResult, FinalizeError>
     where
-        DB: Database + Clone + 'static,
-        P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-            + StateProviderFactory
-            + Clone
-            + 'static,
+        P: StateProviderFactory + StateRootCalculator + Clone + 'static,
     {
         let requests = if ctx
             .chain_spec
@@ -670,7 +666,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         let block_number = ctx.block_env.number.to::<u64>();
 
         let requests_hash = requests.as_ref().map(|requests| requests.requests_hash());
-        let execution_outcome = ExecutionOutcome::new(
+        let execution_outcome = ExecutionOutcome::<Receipt>::new(
             bundle,
             Receipts::from(vec![self
                 .receipts
@@ -690,13 +686,14 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
 
         // calculate the state root
         let start = Instant::now();
-        let state_root = calculate_state_root(
-            provider,
-            ctx.attributes.parent,
-            &execution_outcome,
-            ctx.shared_sparse_mpt_cache.clone(),
-            root_hash_config,
-        )?;
+        //let state_root = calculate_state_root(
+        //    provider,
+        //    ctx.attributes.parent,
+        //    &execution_outcome,
+        //    ctx.shared_sparse_mpt_cache.clone(),
+        //    root_hash_config,
+        //)?;
+        let state_root = provider.calculate_state_root()?;
         let root_hash_time = start.elapsed();
 
         // create the block header

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -20,7 +20,7 @@ use reth_provider::{BlockReader, DatabaseProviderFactory, StateProviderFactory};
 
 use crate::{
     primitives::{Order, OrderId, SimValue, SimulatedOrder, TransactionSignedEcRecoveredWithBlobs},
-    roothash::{calculate_state_root, RootHashConfig, RootHashError, StateRootCalculator},
+    roothash::{RootHashConfig, RootHashError, StateRootCalculator},
     utils::{a2r_withdrawal, calc_gas_limit, timestamp_as_u64, Signer},
 };
 use ahash::HashSet;
@@ -686,14 +686,12 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
 
         // calculate the state root
         let start = Instant::now();
-        //let state_root = calculate_state_root(
-        //    provider,
-        //    ctx.attributes.parent,
-        //    &execution_outcome,
-        //    ctx.shared_sparse_mpt_cache.clone(),
-        //    root_hash_config,
-        //)?;
-        let state_root = provider.calculate_state_root()?;
+        let state_root = provider.calculate_state_root(
+            ctx.attributes.parent,
+            &execution_outcome,
+            ctx.shared_sparse_mpt_cache.clone(),
+            root_hash_config,
+        )?;
         let root_hash_time = start.elapsed();
 
         // create the block header

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -14,13 +14,11 @@ use jsonrpsee::RpcModule;
 use lazy_static::lazy_static;
 use reth::chainspec::chain_value_parser;
 use reth_chainspec::ChainSpec;
-use reth_db::{Database, DatabaseEnv};
+use reth_db::DatabaseEnv;
 use reth_node_api::NodeTypesWithDBAdapter;
 use reth_node_ethereum::EthereumNode;
 use reth_primitives::StaticFileSegment;
-use reth_provider::{
-    DatabaseProviderFactory, HeaderProvider, StateProviderFactory, StaticFileProviderFactory,
-};
+use reth_provider::{HeaderProvider, StateProviderFactory, StaticFileProviderFactory};
 use serde::{Deserialize, Deserializer};
 use serde_with::{serde_as, DeserializeAs};
 use sqlx::PgPool;

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -179,7 +179,6 @@ impl BaseConfig {
     ) -> eyre::Result<
         super::LiveBuilder<
             ProviderFactoryReopener<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>,
-            Arc<DatabaseEnv>,
             SlotSourceType,
         >,
     >
@@ -187,7 +186,7 @@ impl BaseConfig {
         SlotSourceType: SlotSource,
     {
         let provider_factory = self.create_provider_factory()?;
-        self.create_builder_with_provider_factory::<ProviderFactoryReopener<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>, Arc<DatabaseEnv>, SlotSourceType>(
+        self.create_builder_with_provider_factory::<ProviderFactoryReopener<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>, SlotSourceType>(
             cancellation_token,
             sink_factory,
             slot_source,
@@ -197,22 +196,21 @@ impl BaseConfig {
     }
 
     /// Allows instantiating a [`LiveBuilder`] with an existing provider factory
-    pub async fn create_builder_with_provider_factory<P, DB, SlotSourceType>(
+    pub async fn create_builder_with_provider_factory<P, SlotSourceType>(
         &self,
         cancellation_token: tokio_util::sync::CancellationToken,
         sink_factory: Box<dyn UnfinishedBlockBuildingSinkFactory>,
         slot_source: SlotSourceType,
         provider: P,
-    ) -> eyre::Result<super::LiveBuilder<P, DB, SlotSourceType>>
+    ) -> eyre::Result<super::LiveBuilder<P, SlotSourceType>>
     where
-        DB: Database + Clone + 'static,
-        P: DatabaseProviderFactory<DB = DB> + StateProviderFactory + HeaderProvider + Clone,
+        P: StateProviderFactory + HeaderProvider + Clone,
         SlotSourceType: SlotSource,
     {
         let order_input_config = OrderInputConfig::from_config(self)?;
         let (orderpool_sender, orderpool_receiver) =
             mpsc::channel(order_input_config.input_channel_buffer_size);
-        Ok(LiveBuilder::<P, DB, SlotSourceType> {
+        Ok(LiveBuilder::<P, SlotSourceType> {
             watchdog_timeout: self.watchdog_timeout(),
             error_storage_path: self.error_storage_path.clone(),
             simulation_threads: self.simulation_threads,

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, marker::PhantomData, rc::Rc, sync::Arc, thread, time::Duration};
+use std::{cell::RefCell, rc::Rc, sync::Arc, thread, time::Duration};
 
 use crate::{
     building::{
@@ -10,7 +10,6 @@ use crate::{
     },
     live_builder::{payload_events::MevBoostSlotData, simulation::SlotOrderSimResults},
     primitives::{OrderId, SimulatedOrder},
-    roothash::run_trie_prefetcher,
 };
 use reth_provider::StateProviderFactory;
 use revm_primitives::Address;
@@ -33,10 +32,8 @@ pub struct BlockBuildingPool<P> {
     sink_factory: Box<dyn UnfinishedBlockBuildingSinkFactory>,
     orderpool_subscriber: order_input::OrderPoolSubscriber,
     order_simulation_pool: OrderSimulationPool<P>,
-    run_sparse_trie_prefetcher: bool,
+    _run_sparse_trie_prefetcher: bool,
     sbundle_merger_selected_signers: Arc<Vec<Address>>,
-    //TODO: remove me?
-    phantom: PhantomData<P>,
 }
 
 impl<P> BlockBuildingPool<P>
@@ -58,9 +55,8 @@ where
             sink_factory,
             orderpool_subscriber,
             order_simulation_pool,
-            run_sparse_trie_prefetcher,
             sbundle_merger_selected_signers,
-            phantom: PhantomData,
+            _run_sparse_trie_prefetcher: run_sparse_trie_prefetcher,
         }
     }
 

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -2,8 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use reth::revm::cached::CachedReads;
-use reth_db::Database;
-use reth_provider::{BlockReader, DatabaseProviderFactory, HeaderProvider, StateProviderFactory};
+use reth_provider::{HeaderProvider, StateProviderFactory};
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 use sysperf::{format_results, gather_system_info, run_all_benchmarks};
@@ -51,33 +50,23 @@ pub trait LiveBuilderConfig: Debug + DeserializeOwned + Sync {
     /// Create a concrete builder
     ///
     /// Desugared from async to future to keep clippy happy
-    fn new_builder<P, DB>(
+    fn new_builder<P>(
         &self,
         provider: P,
         cancellation_token: CancellationToken,
-    ) -> impl std::future::Future<Output = eyre::Result<LiveBuilder<P, DB, MevBoostSlotDataGenerator>>>
-           + Send
+    ) -> impl std::future::Future<Output = eyre::Result<LiveBuilder<P, MevBoostSlotDataGenerator>>> + Send
     where
-        DB: Database + Clone + 'static,
-        P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-            + StateProviderFactory
-            + HeaderProvider
-            + Clone
-            + 'static;
+        P: StateProviderFactory + HeaderProvider + Clone + 'static;
 
     /// Patch until we have a unified way of backtesting using the exact algorithms we use on the LiveBuilder.
     /// building_algorithm_name will come from the specific configuration.
-    fn build_backtest_block<P, DB>(
+    fn build_backtest_block<P>(
         &self,
         building_algorithm_name: &str,
         input: BacktestSimulateBlockInput<'_, P>,
     ) -> eyre::Result<(Block, CachedReads)>
     where
-        DB: Database + Clone + 'static,
-        P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-            + StateProviderFactory
-            + Clone
-            + 'static;
+        P: StateProviderFactory + Clone + 'static;
 }
 
 /// print_version_info func that will be called on command Cli::Version

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -14,6 +14,7 @@ use crate::{
     live_builder::{
         base_config::load_config_toml_and_env, payload_events::MevBoostSlotDataGenerator,
     },
+    roothash::StateRootCalculator,
     telemetry,
     utils::build_info::Version,
 };
@@ -56,7 +57,7 @@ pub trait LiveBuilderConfig: Debug + DeserializeOwned + Sync {
         cancellation_token: CancellationToken,
     ) -> impl std::future::Future<Output = eyre::Result<LiveBuilder<P, MevBoostSlotDataGenerator>>> + Send
     where
-        P: StateProviderFactory + HeaderProvider + Clone + 'static;
+        P: StateProviderFactory + StateRootCalculator + HeaderProvider + Clone + 'static;
 
     /// Patch until we have a unified way of backtesting using the exact algorithms we use on the LiveBuilder.
     /// building_algorithm_name will come from the specific configuration.
@@ -66,7 +67,7 @@ pub trait LiveBuilderConfig: Debug + DeserializeOwned + Sync {
         input: BacktestSimulateBlockInput<'_, P>,
     ) -> eyre::Result<(Block, CachedReads)>
     where
-        P: StateProviderFactory + Clone + 'static;
+        P: StateProviderFactory + StateRootCalculator + Clone + 'static;
 }
 
 /// print_version_info func that will be called on command Cli::Version

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -48,14 +48,11 @@ use ethereum_consensus::{
 use eyre::Context;
 use reth::revm::cached::CachedReads;
 use reth_chainspec::{Chain, ChainSpec, NamedChain};
-use reth_db::{Database, DatabaseEnv};
+use reth_db::DatabaseEnv;
 use reth_node_api::NodeTypesWithDBAdapter;
 use reth_node_ethereum::EthereumNode;
 use reth_primitives::StaticFileSegment;
-use reth_provider::{
-    BlockReader, DatabaseProviderFactory, HeaderProvider, StateProviderFactory,
-    StaticFileProviderFactory,
-};
+use reth_provider::{HeaderProvider, StateProviderFactory, StaticFileProviderFactory};
 use serde::Deserialize;
 use serde_with::{serde_as, OneOrMany};
 use std::{

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     mev_boost::BLSBlockSigner,
     primitives::mev_boost::{MevBoostRelay, RelayConfig},
-    roothash::RootHashConfig,
+    roothash::{RootHashConfig, StateRootCalculator},
     utils::{build_info::rbuilder_version, ProviderFactoryReopener, Signer},
     validation_api_client::ValidationAPIClient,
 };
@@ -296,7 +296,7 @@ impl LiveBuilderConfig for Config {
         cancellation_token: tokio_util::sync::CancellationToken,
     ) -> eyre::Result<super::LiveBuilder<P, MevBoostSlotDataGenerator>>
     where
-        P: StateProviderFactory + HeaderProvider + Clone + 'static,
+        P: StateProviderFactory + HeaderProvider + StateRootCalculator + Clone + 'static,
     {
         let (sink_sealed_factory, relays) = self.l1_config.create_relays_sealed_sink_factory(
             self.base_config.chain_spec()?,
@@ -349,7 +349,7 @@ impl LiveBuilderConfig for Config {
         input: BacktestSimulateBlockInput<'_, P>,
     ) -> eyre::Result<(Block, CachedReads)>
     where
-        P: StateProviderFactory + Clone + 'static,
+        P: StateProviderFactory + StateRootCalculator + Clone + 'static,
     {
         let builder_cfg = self.builder(building_algorithm_name)?;
         match builder_cfg.builder {
@@ -509,7 +509,7 @@ pub fn create_builders<P>(
     root_hash_config: RootHashConfig,
 ) -> Vec<Arc<dyn BlockBuildingAlgorithm<P>>>
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     configs
         .into_iter()
@@ -522,7 +522,7 @@ fn create_builder<P>(
     root_hash_config: &RootHashConfig,
 ) -> Arc<dyn BlockBuildingAlgorithm<P>>
 where
-    P: StateProviderFactory + Clone + 'static,
+    P: StateProviderFactory + StateRootCalculator + Clone + 'static,
 {
     match cfg.builder {
         SpecificBuilderConfig::OrderingBuilder(order_cfg) => Arc::new(

--- a/crates/rbuilder/src/roothash/mod.rs
+++ b/crates/rbuilder/src/roothash/mod.rs
@@ -5,15 +5,10 @@ use eth_sparse_mpt::reth_sparse_trie::{
     calculate_root_hash_with_sparse_trie, trie_fetcher::FetchNodeError, SparseTrieError,
     SparseTrieSharedCache,
 };
-use reth::builder::BuilderContext;
 use reth::providers::{providers::ConsistentDbView, ExecutionOutcome};
-use reth_db::transaction::{DbTx, DbTxMut};
 use reth_errors::ProviderError;
-use reth_node_api::{FullNodeTypes, NodeTypesWithDB};
-use reth_provider::{
-    providers::ProviderNodeTypes, BlockReader, DatabaseProvider, DatabaseProviderFactory,
-    FullProvider, ProviderFactory, StaticFileProviderFactory,
-};
+use reth_node_api::NodeTypesWithDB;
+use reth_provider::{providers::ProviderNodeTypes, BlockReader, DatabaseProviderFactory};
 use reth_trie::TrieInput;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use tracing::trace;

--- a/crates/reth-rbuilder/src/main.rs
+++ b/crates/reth-rbuilder/src/main.rs
@@ -8,6 +8,7 @@
 use clap::{Args, Parser};
 use rbuilder::{
     live_builder::{base_config::load_config_toml_and_env, cli::LiveBuilderConfig, config::Config},
+    roothash::StateRootCalculator,
     telemetry,
 };
 use reth::{chainspec::EthereumChainSpecParser, cli::Cli};
@@ -16,7 +17,7 @@ use reth_node_builder::{
     engine_tree_config::{
         TreeConfig, DEFAULT_MEMORY_BLOCK_BUFFER_TARGET, DEFAULT_PERSISTENCE_THRESHOLD,
     },
-    EngineNodeLauncher,
+    EngineNodeLauncher, NodeTypesWithDB,
 };
 use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
 use reth_provider::{
@@ -127,6 +128,7 @@ where
     P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
         + StateProviderFactory
         + HeaderProvider
+        + StateRootCalculator
         + Clone
         + 'static,
 {

--- a/crates/reth-rbuilder/src/main.rs
+++ b/crates/reth-rbuilder/src/main.rs
@@ -17,7 +17,7 @@ use reth_node_builder::{
     engine_tree_config::{
         TreeConfig, DEFAULT_MEMORY_BLOCK_BUFFER_TARGET, DEFAULT_PERSISTENCE_THRESHOLD,
     },
-    EngineNodeLauncher, NodeTypesWithDB,
+    EngineNodeLauncher,
 };
 use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
 use reth_provider::{

--- a/crates/transaction-pool-bundle-ext/bundle_pool_ops/rbuilder/src/lib.rs
+++ b/crates/transaction-pool-bundle-ext/bundle_pool_ops/rbuilder/src/lib.rs
@@ -26,6 +26,7 @@ use rbuilder::{
         SlotSource,
     },
     primitives::{Bundle, BundleReplacementKey, Order},
+    roothash::StateRootCalculator,
     telemetry,
 };
 use reth_db_api::Database;
@@ -89,12 +90,9 @@ impl SlotSource for OurSlotSource {
 }
 
 impl BundlePoolOps {
-    pub async fn new<P, DB>(
-        provider: P,
-        rbuilder_config_path: impl AsRef<Path>,
-    ) -> Result<Self, Error>
+    pub async fn new<P>(provider: P, rbuilder_config_path: impl AsRef<Path>) -> Result<Self, Error>
     where
-        P: StateProviderFactory + HeaderProvider + Clone + 'static,
+        P: StateProviderFactory + StateRootCalculator + HeaderProvider + Clone + 'static,
     {
         // Create the payload source to trigger new block building
         let cancellation_token = CancellationToken::new();

--- a/crates/transaction-pool-bundle-ext/bundle_pool_ops/rbuilder/src/lib.rs
+++ b/crates/transaction-pool-bundle-ext/bundle_pool_ops/rbuilder/src/lib.rs
@@ -94,12 +94,7 @@ impl BundlePoolOps {
         rbuilder_config_path: impl AsRef<Path>,
     ) -> Result<Self, Error>
     where
-        DB: Database + Clone + 'static,
-        P: DatabaseProviderFactory<DB = DB, Provider: BlockReader>
-            + StateProviderFactory
-            + HeaderProvider
-            + Clone
-            + 'static,
+        P: StateProviderFactory + HeaderProvider + Clone + 'static,
     {
         // Create the payload source to trigger new block building
         let cancellation_token = CancellationToken::new();
@@ -136,7 +131,7 @@ impl BundlePoolOps {
         // Build and run the process
         let builder = config
             .base_config
-            .create_builder_with_provider_factory::<P, DB, OurSlotSource>(
+            .create_builder_with_provider_factory::<P, OurSlotSource>(
                 cancellation_token,
                 Box::new(sink_factory),
                 slot_source,

--- a/crates/transaction-pool-bundle-ext/bundle_pool_ops/rbuilder/src/lib.rs
+++ b/crates/transaction-pool-bundle-ext/bundle_pool_ops/rbuilder/src/lib.rs
@@ -29,9 +29,8 @@ use rbuilder::{
     roothash::StateRootCalculator,
     telemetry,
 };
-use reth_db_api::Database;
 use reth_primitives::TransactionSigned;
-use reth_provider::{BlockReader, DatabaseProviderFactory, HeaderProvider, StateProviderFactory};
+use reth_provider::{HeaderProvider, StateProviderFactory};
 use tokio::{
     sync::{
         mpsc::{self, error::SendError},

--- a/crates/transaction-pool-bundle-ext/bundle_pool_ops/rbuilder/src/lib.rs
+++ b/crates/transaction-pool-bundle-ext/bundle_pool_ops/rbuilder/src/lib.rs
@@ -6,6 +6,11 @@
 use core::fmt;
 use std::{fmt::Formatter, path::Path, sync::Arc, time::Duration};
 
+//NOTE: without this linter complies that reth_db_api is unused
+// but we cannot remove it because it is required by "reth-db-api/optimism"
+// which linter doesn't pick up
+use reth_db_api as _;
+
 use alloy_primitives::U256;
 use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
 use derive_more::From;


### PR DESCRIPTION
## 📝 Summary
Through the whole codebase, `DatabaseProviderFactory<DB = reth_db::Database, Provider: BlockReader>` is replaced with simpler, less restrictive trait bound `SateRootCalculator`.

## 💡 Motivation and Context

### Motivation
Make `rbuilder` less coupled to the `reth` so we can have an easier time using it with other clients.

### Context
The trait bound  `DatabaseProviderFactory<DB = reth_db::Database, Provider: BlockReader>` on the provider is only needed for 2 "things":
1. State root calculation
2. State trie prefetching (to be "dealt with" in the separate PR)

The problem with the current solution is that if we want to use `rbuilder` with any other client (than `reth`), we are bound to the `reth's` state representation, and this is most obvious during state root calculation, as current state root calculation relies on some state assumptions which are not necessarily true for clients other than `reth`. 

Generalizing over state root calculation will give us the simplest path for making `rbuilder` truly client agnostic. 
Efforts towards this goal are already underway and can be observed in [the following branch](https://github.com/NethermindEth/rbuilder/compare/feat/remove-database-trait-bound...NethermindEth:rbuilder:spike/rebase-on-remove-db-trait-bound), which implements "remote state provider" (the idea being that state required by `rbuilder` can be provided via RPC).

### Implementation details
Through the code, we are bounding _the injected provider_  by the `SateRootCalulator` trait ([code example](https://github.com/NethermindEth/rbuilder/blob/4972f95d937ce76dffb0ef06726a35d176d231a1/crates/rbuilder/src/building/builders/block_building_helper.rs#L150)). I've decided for this approach for 2 reasons:
1. The state root calculation is, in fact, dependent on the provider 
2. It follows the current approach (where the injected provider was bound by `DatabaseProviderFactory` for the same reason of state root calculation)

I have played around with the implementation where `StateRootCalculator` is injected alongside the provider ([here](https://github.com/NethermindEth/rbuilder/compare/develop...NethermindEth:rbuilder:feat/no-db-tarit-bound-separate-root-calculator)), but I don't like it. IMO, it just brings "noise," and I don't see any benefit. 

#### `calculate_state_root` function args

The function signature for the `calculate_state_root` looks as follows:

```Rust
pub trait StateRootCalculator {
    fn calculate_state_root(
        &self,
        parent_hash: B256,
        outcome: &ExecutionOutcome,
        sparse_trie_shared_cache: SparseTrieSharedCache,
        config: RootHashConfig,
    ) -> Result<B256, RootHashError>;
}
```

I'm not super happy about this because args. require `rbuilder` specific "stuff," which is not necessary for "general" state root calculation (I'm referring to the  `sparse_trie_shared_cache` and the `config`).
That being said, we _do_ have these available at the call site, and I didn't want to overcomplicate this PR for the sake of coding purity :)
If need be we can refactor the `StateRootCalculator` trait to be just `prev_root, diff -> result` and  "solve" the additional requirements specific for the `ProviderFactoryReopener`/`rbuilder`  by either extending `ProviderFactoryReopener` with necessary fields, or look into solution using HOFs/closures. 

####  State trie prefetching 

This is left as `TODO,` I want to receive the feedback on this PR, and then I'll tackle the `run_trie_prefetcher.`
My plan for this is similar to the approach I took for the `StateRootCalculator` - we can make this generic over the provider, and, e.g., prefetch the trie via RPC for the above-mentioned "remote state provider."

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
